### PR TITLE
Fix expire timestamp getting out of control for long running locks

### DIFF
--- a/src/mongolock.py
+++ b/src/mongolock.py
@@ -27,7 +27,6 @@ class MongoLock(object):
           - `acquire_retry_step` (optional)- time in seconds between retries while trying to acquire the lock,
              if specified - `host` parameter will be skipped
         """
-        self.lock_expire = None
         self.acquire_retry_step = acquire_retry_step
         if isinstance(collection, Collection):
             self.collection = collection


### PR DESCRIPTION
Touching a lock that has been held for a long time causes the expire timestamp to jump too far into the future.

Adding an expire parameter to the touch method fixes this, allowing long running locks to still expire as expected.
